### PR TITLE
fix: make tool/reasoning toggles work from unfocused panels

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -411,17 +411,28 @@ function MissionControlInner() {
   const activePanelAgent = activePanel?.agentId ? agents.find(a => a.id === activePanel.agentId) : undefined;
 
   // Handlers for updating per-panel settings
+  const handlePanelShowToolsChange = useCallback((panelId: string, show: boolean) => {
+    setActivePanel(panelId);
+    updatePanelSettings(panelId, { showTools: show });
+  }, [setActivePanel, updatePanelSettings]);
+
+  const handlePanelShowReasoningChange = useCallback((panelId: string, show: boolean) => {
+    setActivePanel(panelId);
+    updatePanelSettings(panelId, { showReasoning: show });
+  }, [setActivePanel, updatePanelSettings]);
+
+  // Active-panel wrappers used by mobile controls
   const handleShowToolsChange = useCallback((show: boolean) => {
     if (activePanel?.id) {
-      updatePanelSettings(activePanel.id, { showTools: show });
+      handlePanelShowToolsChange(activePanel.id, show);
     }
-  }, [activePanel?.id, updatePanelSettings]);
+  }, [activePanel?.id, handlePanelShowToolsChange]);
 
   const handleShowReasoningChange = useCallback((show: boolean) => {
     if (activePanel?.id) {
-      updatePanelSettings(activePanel.id, { showReasoning: show });
+      handlePanelShowReasoningChange(activePanel.id, show);
     }
-  }, [activePanel?.id, updatePanelSettings]);
+  }, [activePanel?.id, handlePanelShowReasoningChange]);
 
   // Handler to open chat panel for an agent
   const handleSelectAgent = useCallback((agentId: string) => {
@@ -886,8 +897,8 @@ function MissionControlInner() {
             onResetSession={handleResetSession}
             onModelChange={handleModelChange}
             onThinkingChange={handleThinkingChange}
-            onShowToolsChange={handleShowToolsChange}
-            onShowReasoningChange={handleShowReasoningChange}
+            onShowToolsChange={handlePanelShowToolsChange}
+            onShowReasoningChange={handlePanelShowReasoningChange}
             onRefreshChat={handleRefreshChat}
             onCreateAgent={handleCreateAgentRequest}
             onUpdateAgent={handleUpdateAgentRequest}

--- a/components/panels/PanelContainer.tsx
+++ b/components/panels/PanelContainer.tsx
@@ -38,8 +38,8 @@ interface PanelContainerProps {
   onResetSession?: (agentId: string) => void;
   onModelChange?: (modelId: string, provider?: string) => void;
   onThinkingChange?: (thinking: 'off' | 'low' | 'medium' | 'high') => void;
-  onShowToolsChange?: (show: boolean) => void;
-  onShowReasoningChange?: (show: boolean) => void;
+  onShowToolsChange?: (panelId: string, show: boolean) => void;
+  onShowReasoningChange?: (panelId: string, show: boolean) => void;
   onRefreshChat?: (agentId: string) => void;
   onCreateAgent: (payload: {
     id?: string;
@@ -137,6 +137,7 @@ export function PanelContainer({
         <div 
           key={panel.id} 
           className="flex flex-col border-r last:border-r-0 border-border min-h-0 overflow-hidden"
+          onMouseDownCapture={() => onPanelActivate(panel.id)}
         >
           <PanelHeader
             title={panel.title}
@@ -148,8 +149,16 @@ export function PanelContainer({
             onResetSession={panel.type === 'chat' && panel.agentId ? () => onResetSession?.(panel.agentId!) : undefined}
             showTools={panel.type === 'chat' ? panel.settings?.showTools ?? false : undefined}
             showReasoning={panel.type === 'chat' ? panel.settings?.showReasoning ?? true : undefined}
-            onShowToolsChange={panel.type === 'chat' ? onShowToolsChange : undefined}
-            onShowReasoningChange={panel.type === 'chat' ? onShowReasoningChange : undefined}
+            onShowToolsChange={
+              panel.type === 'chat'
+                ? (show) => onShowToolsChange?.(panel.id, show)
+                : undefined
+            }
+            onShowReasoningChange={
+              panel.type === 'chat'
+                ? (show) => onShowReasoningChange?.(panel.id, show)
+                : undefined
+            }
             models={panel.type === 'chat' ? models : undefined}
             currentModel={panel.type === 'chat' ? panel.model : undefined}
             onModelChange={panel.type === 'chat' ? onModelChange : undefined}


### PR DESCRIPTION
## Summary
Fixes panel focus behavior so Tool/Reasoning toggles work correctly even when used from an unfocused panel.

### Changes
- make panel-level toggle handlers explicit (`panelId` + value), instead of relying on current `activePanel`
- when toggles are changed, that panel is activated first (`setActivePanel(panelId)`)
- add `onMouseDownCapture` on each panel container so interacting with anything inside a panel focuses it
- keep mobile controls working via active-panel wrappers

## Why
Previously, toggles in an unfocused panel could update the wrong panel (or appear not to work) because handlers wrote to the globally active panel.

## Validation
- `npm run build` passes
