### PR TITLE
docs: update README/notes docs for latest UX and chat-input features

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ OPENCLAW_GATEWAY_TOKEN=your_gateway_token_here
 - Thinking level controls (`off`, `low`, `medium`, `high`)
 - Tool visibility toggle (verbose)
 - Reasoning visibility toggle
+- Panel-aware tool/reasoning toggles (applies to the panel you click/focus)
+- Token usage indicator above chat input (`used/context`, color-coded) with unlimited-context awareness
 
 ### 5) Cron jobs
 - List/create/update/delete cron jobs
@@ -81,6 +83,9 @@ OPENCLAW_GATEWAY_TOKEN=your_gateway_token_here
 - Persistent notes stored locally (`~/.oc-mission-control/notes.json`)
 - Groups + tags + custom tag colors
 - Image upload/paste support
+- Native `#` mentions in chat (`#notes ...`) to browse groups/notes and insert note content
+- Inserted note content is wrapped in `<note>...</note>` for cleaner context
+- Selecting a note can auto-attach its note image to the outgoing message
 - Quick filtering and copy actions
 
 ### 7) Extensions framework
@@ -92,6 +97,7 @@ OPENCLAW_GATEWAY_TOKEN=your_gateway_token_here
 ### 8) UX and resilience
 - Desktop + mobile-optimized controls
 - Multi-panel workspace with persisted state
+- Scrollable dropdowns for long Agent/Cron lists
 - Stream state recovery across refreshes
 - Activity history persisted across restarts
 

--- a/docs/NOTES_FEATURE.md
+++ b/docs/NOTES_FEATURE.md
@@ -129,6 +129,16 @@ interface UseNotesReturn {
 }
 ```
 
+#### Native chat mentions (`hooks/useNativeChatInput.ts` + `components/chat/ChatInput.tsx`)
+Mission Control also exposes Notes directly in chat input via `#` mentions.
+
+**Behavior:**
+- Typing `#` opens native providers (currently Notes)
+- `#notes` shows note groups, then notes within each group
+- Selecting a note inserts its content into the chat input wrapped in `<note>...</note>`
+- If the note includes an image, Mission Control attempts to fetch and attach that image automatically
+- The textarea auto-resizes after mention insertion for cleaner UX
+
 ### Type Definitions
 
 #### Note (`types/note.ts`)
@@ -184,6 +194,21 @@ openPanel('notes', { selectedGroup: 'Commands' });
 - **Copy/Download Image**: If a note has an image, hover to see copy-to-clipboard (browser permitting) or download icons.
 - **Delete**: Hover over a note and click the trash icon.
 - **Manage Groups**: In the input area group dropdown, hover over custom groups to see the delete icon. Note: "General" is a permanent fallback group.
+
+### Using Notes in Chat via `#` Mentions
+
+1. In any chat panel, type `#` to open native mention providers.
+2. Select `Notes`, then optionally narrow by group (for example: `#notes Ideas`).
+3. Pick a note from the dropdown.
+4. Mission Control inserts:
+   ```text
+   <note>
+   ...note content...
+   </note>
+   ```
+5. If the selected note has an image, it is auto-attached to the outgoing message when possible.
+
+This workflow is useful for quickly grounding an agent with structured note context without copy/paste.
 
 ## WebSocket Protocol
 


### PR DESCRIPTION
## Summary
Updates docs based on master commits from the last 24 hours.

### README
- Added panel-aware tool/reasoning toggle behavior
- Documented token usage indicator above chat input (including unlimited-context handling)
- Documented native `#notes` chat mentions with note insertion and image auto-attach
- Added note on scrollable Agent/Cron dropdowns

### docs/NOTES_FEATURE.md
- Added architecture notes for native chat mentions (`useNativeChatInput` + `ChatInput`)
- Added end-user usage flow for `#` note mentions and `<note>...</note>` insertion

## Why
Recent feature and UX changes (token usage visibility, native note mentions, panel setting focus behavior, dropdown usability) were not fully reflected in docs.
