### PR TITLE
feat(ui): make Stop run button red while running

### DIFF
--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -453,7 +453,11 @@ export function ChatInput({
           <button
             onClick={handleButtonClick}
             disabled={Boolean(disabled) || (!isRunning && !value.trim() && attachments.length === 0)}
-            className="bg-primary text-primary-foreground p-2.5 md:px-4 md:py-3 rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+            className={`p-2.5 md:px-4 md:py-3 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0 ${
+              isRunning
+                ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                : 'bg-primary text-primary-foreground hover:bg-primary/90'
+            }`}
             title={isRunning ? 'Stop generation' : 'Send message'}
           >
             {isRunning ? <Square className="w-5 h-5" /> : <Send className="w-5 h-5" />}


### PR DESCRIPTION
## Summary
- make the chat input action button use destructive (red) styling when a run is active
- keep the default primary styling for normal send state

## Why
- improves stop action visibility and urgency

## Scope
- UI-only change in components/chat/ChatInput.tsx