### PR TITLE
chore(release): daily changelog 2026-02-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [0.2.0] - 2026-02-22
 ### Meta
 - Bump: none (score: 0)
-- Range: 174a5614e2266b7015d4403e5dec7a6e3afb77b4..174a5614e2266b7015d4403e5dec7a6e3afb77b4
+- Range: [174a561](https://github.com/imadaitelarabi/openclaw-mc/commit/174a5614e2266b7015d4403e5dec7a6e3afb77b4)..[174a561](https://github.com/imadaitelarabi/openclaw-mc/commit/174a5614e2266b7015d4403e5dec7a6e3afb77b4)
 
 ### Other
-- No changes
+- No changes since [174a561](https://github.com/imadaitelarabi/openclaw-mc/commit/174a5614e2266b7015d4403e5dec7a6e3afb77b4)
 
 
 


### PR DESCRIPTION
Automated daily changelog + version bump.\n\n- Bump: none\n- Score: 0\n- Range: 174a5614e2266b7015d4403e5dec7a6e3afb77b4..174a5614e2266b7015d4403e5dec7a6e3afb77b4\n