### PR TITLE
docs: highlight GitHub panels and installer updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ It gives you a single place to monitor agents, run chats, manage sessions, and o
 curl -fsSL https://raw.githubusercontent.com/imadaitelarabi/openclaw-mc/master/scripts/install-and-run.sh | bash
 ```
 
+> The installer now detects common openclaw-mc clones, reuses an existing checkout, and pulls updates instead of forcing a fresh clone. See [docs/FEATURES.md](./docs/FEATURES.md) for details.
+
 ### Option B: Manual install
 
 ```bash
@@ -114,6 +116,12 @@ OPENCLAW_GATEWAY_TOKEN=your_gateway_token_here
 - Scrollable dropdowns for long Agent/Cron lists
 - Stream state recovery across refreshes
 - Activity history persisted across restarts
+
+### 9) GitHub issue & PR detail panels
+
+- Dedicated GitHub issue and pull request panels surface title, status, metadata, markdown bodies, and the latest conversation/review comments alongside a fast "Open in GitHub" link.
+- Chat links pointing to `github.com/.../issues/...` or `/pull/...` now open those panels in-place thanks to the new [chat link matcher registry](./docs/FEATURES.md).
+- See [docs/FEATURES.md](./docs/FEATURES.md) for the full rundown on these GitHub extension enhancements.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,17 @@
+# Feature Highlights (February 22, 2026)
+
+## GitHub extension: issue & PR detail panels
+
+- The GitHub extension now ships with dedicated **issue** and **pull-request detail panels**. They show the title, status badge, author, assignees, labels, timestamps, and the markdown body with an expandable/scrollable preview. Each panel also loads the latest conversation and review comments (with a "Load more" control), and offers a direct link to open the resource in GitHub.
+- These panels can surface from the status bar dropdown (Open Panel entries) or anywhere in the app that wants an in-app view of a specific GitHub URL.
+- The extension now exposes a richer `GitHubAPI` client that centralizes all of the REST calls behind the new panels (repo listing, issue/PR details, issue comments, review comments, and search helpers).
+
+## Intercepting GitHub links in chat
+
+- Chat messages no longer just open GitHub issue/PR links in a browser tab. A new `chatLinkMatcherRegistry` lets extensions register URL matchers so clicks can open in-app panels instead. The GitHub extension registers a matcher that parses `https://github.com/{owner}/{repo}/issues/{#}` and `/pull/{#}` URLs and routes them to the new detail panels.
+- The registry is extension-agnostic and can host multiple matchers (ordered by priority), enabling future integrations to intercept links as well.
+
+## Installer script: detect & update existing clones
+
+- The `scripts/install-and-run.sh` helper now scans common install directories, avoids re-cloning when a valid checkout already exists, and updates it in place instead. It also warns when the existing installation lives outside the default directory and reuses that path.
+- The script still installs or upgrades prerequisites (git/curl, Node.js) but now reuses the existing repo state whenever possible, simplifying repeat runs on a machine that already has OpenClaw MC installed.


### PR DESCRIPTION
## Summary\n- add a feature highlight doc that explains the new GitHub issue/PR detail panels, chat link interception, and installer reuse behavior\n- reference the new feature notes from the README so the GitHub extension updates are visible in the main overview\n\n## Testing\n- n/a