### PR TITLE
chore(release): daily changelog 2026-02-28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.7.1] - 2026-02-28
+### Meta
+- Bump: patch (score: 3)
+- Range: since 24 hours
+
+### Other
+- Merge pull request [#151](https://github.com/imadaitelarabi/openclaw-mc.git/pull/151) from imadaitelarabi/changelog/daily-2026-02-27 ([a2ccbdd](https://github.com/imadaitelarabi/openclaw-mc.git/commit/a2ccbdd7d5cbbff64c1d8c8ac41bc77e5fc7306d))
+
+
+
 ## [0.7.0] - 2026-02-27
 ### Meta
 - Bump: minor (score: 26)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mission-control",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mission-control",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mission-control",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch server/index.ts",


### PR DESCRIPTION
Automated daily changelog + version bump.\n\n- Bump: patch\n- Score: 3\n- Range: since 24 hours\n